### PR TITLE
Remove asset assignment logic in favor of filtering logic

### DIFF
--- a/projects/lib/src/admin/components/asset-list/asset-list.component.ts
+++ b/projects/lib/src/admin/components/asset-list/asset-list.component.ts
@@ -10,7 +10,9 @@ import {
   ListArgs
 } from '@ordercloud/headstart-sdk';
 import { NgxSpinnerService } from 'ngx-spinner';
-import { ResourceType } from '../../../shared/models/resource-type.interface';
+import { merge as _merge} from 'lodash';
+import { ResourceType } from 'projects/lib/src/shared/models/resource-type.interface';
+import { ParentResourceType } from 'projects/lib/src/shared/models/parent-resource-type.interface';
 
 const ASSET_TYPE_IMAGE = 'Image';
 type ASSET_TYPE_IMAGE = typeof ASSET_TYPE_IMAGE;
@@ -33,9 +35,10 @@ type AssetType =
   styleUrls: ['./asset-list.component.scss'],
 })
 export class AssetListComponent implements OnInit {
+  @Input() defaultFilterOptions?: Partial<ListArgs> = {};
   @Input() resourceType?: ResourceType = null;
   @Input() resourceID?: string = null;
-  @Input() parentResourceID?: string = null;
+  @Input() parentResourceID?: ParentResourceType = null;
   assets: any;
   modalReference: NgbModalRef;
   loading = true;
@@ -53,30 +56,32 @@ export class AssetListComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    if (!this.resourceType || !this.resourceID) {
-      throw new Error(
-        'cms-asset-list is missing required props resourceType or resourceID'
-      );
-    }
     this.listAssets(this.selectedTab, null);
   }
 
   listAssets(assetType: AssetType, searchTerm: string) {
     this.spinner.show();
-    let options: ListArgs<Asset> = {
-      filters: { Type: assetType },
-    };
-    // TODO: ListAssets will not accept search as a parameter, refactor for client side searching
+    let options: ListArgs<Asset> = _merge( {filters: { Type: assetType }}, this.defaultFilterOptions );
     if (searchTerm) {
       options = { ...options, search: searchTerm, searchOn: ['Title'] };
     }
-    return HeadStartSDK.Assets.ListAssets(this.resourceType, this.resourceID, options)
-      .then((response) => this.assets = response.Items ? response.Items.filter(asset => asset.Type === assetType) : [])
-      .catch((ex) => ex)
-      .finally(() => {
-        this.loading = false;
-        this.spinner.hide();
-      });
+    if (this.resourceID && this.resourceType) {
+      return HeadStartSDK.Assets.ListAssets(this.resourceType, this.resourceID)
+        .then((response) => this.assets = response.Items.filter(a => a.Type === assetType))
+        .catch((ex) => ex)
+        .finally(() => {
+          this.loading = false;
+          this.spinner.hide();
+        });
+    } else {
+      return HeadStartSDK.Assets.List(options)
+        .then((response) => this.assets = response.Items)
+        .catch((ex) => ex)
+        .finally(() => {
+          this.loading = false;
+          this.spinner.hide();
+        });
+    }
   }
 
   handleUploadAssetModal(modalRef) {

--- a/projects/lib/src/admin/components/asset-list/asset-list.component.ts
+++ b/projects/lib/src/admin/components/asset-list/asset-list.component.ts
@@ -10,7 +10,7 @@ import {
   ListArgs
 } from '@ordercloud/headstart-sdk';
 import { NgxSpinnerService } from 'ngx-spinner';
-import { merge as _merge} from 'lodash';
+import { merge as _merge, isEmpty as _isEmpty } from 'lodash';
 import { ResourceType } from 'projects/lib/src/shared/models/resource-type.interface';
 import { ParentResourceType } from 'projects/lib/src/shared/models/parent-resource-type.interface';
 
@@ -56,6 +56,9 @@ export class AssetListComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    if (this.resourceID && this.resourceType && !_isEmpty(this.defaultFilterOptions)) {
+      console.warn('Because you\'ve provided a resourceType and resourceID, defaultFilterOptions will be ignored as they are not currently supported while listing assets per resource'); 
+    }
     this.listAssets(this.selectedTab, null);
   }
 

--- a/projects/lib/src/admin/components/asset-update/asset-update.component.html
+++ b/projects/lib/src/admin/components/asset-update/asset-update.component.html
@@ -7,11 +7,11 @@
             class="card-img-top img-fluid flex-shrink-0" [src]="assetForm.controls['Url'].value" />
           <ng-container *ngIf="isNew">
             <small>{{ (assetForm?.controls)["FileName"]?.value }}</small>
-            <button *ngIf="(assetForm?.controls)['Url']?.value" type="button" class="btn btn-sm btn-danger"
+            <button *ngIf="(assetForm?.controls)['File']?.value" type="button" class="btn btn-sm btn-danger"
               (click)="deleteFile()">
               Remove {{ assetType }}
             </button>
-            <div *ngIf="!(assetForm?.controls)['Url']?.value" class="dropzone" cmsDragAndDrop
+            <div *ngIf="!(assetForm?.controls)['File']?.value" class="dropzone" cmsDragAndDrop
               (fileDropped)="uploadFile($event)">
               <input type="file" #fileDropRef id="fileDropRef" (change)="uploadFile($event.target.files[0])" />
               <p class="mb-0">Drage and drop {{ assetType }} here
@@ -25,11 +25,7 @@
           <button *ngIf="!isNew" type="button" class="btn btn-default">
             <label class="mb-0" for="{{ asset ? asset.ID : 'new' }}">
               <small>
-                {{
-                assetForm.controls["Url"] && assetForm.controls["Url"].value
-                  ? "Replace"
-                  : "Add"
-              }}
+                {{assetForm.controls['Url'].value ? "Replace" : "Add"}}
                 <span class="d-none d-sm-block">{{ assetType }}</span>
               </small>
             </label>
@@ -40,12 +36,7 @@
         <div class="form-group">
           <label for="Title">Title</label>
           <input type="text" formControlName="Title" class="form-control" id="Title" placeholder="Title"
-            autofocus="true" pattern="([A-Za-z0-9\-\_]+)" autocomplete="off" />
-        </div>
-        <div class="form-group">
-          <label for="ID">ID</label>
-          <input type="text" formControlName="ID" class="form-control" id="ID" placeholder="ID" autofocus="true"
-            pattern="([A-Za-z0-9\-\_]+)" autocomplete="off" />
+            autofocus="true" autocomplete="off" />
         </div>
         <div class="form-group">
           <label for="Url">Url</label>

--- a/projects/lib/src/admin/components/asset-update/asset-update.component.ts
+++ b/projects/lib/src/admin/components/asset-update/asset-update.component.ts
@@ -17,8 +17,8 @@ export class AssetUpdateComponent implements OnInit {
   @Input() asset?: any;
   @Input() assetType: any;
   @Input() isNew: boolean;
-  @Input() resourceType: ResourceType = null;
-  @Input() resourceID: string = null;
+  @Input() resourceType?: ResourceType = null;
+  @Input() resourceID?: string = null;
   @Output() onSubmit = new EventEmitter();
   @Output() onDelete = new EventEmitter();
 

--- a/projects/lib/src/admin/components/asset-upload/asset-upload.component.ts
+++ b/projects/lib/src/admin/components/asset-upload/asset-upload.component.ts
@@ -1,20 +1,15 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ResourceType } from 'projects/lib/src/shared/models/resource-type.interface';
 
 @Component({
   selector: 'cms-asset-upload',
   templateUrl: './asset-upload.component.html',
   styleUrls: ['./asset-upload.component.scss']
 })
-export class AssetUploadComponent implements OnInit {
+export class AssetUploadComponent {
   @Input() assetType;
-  @Input() resourceType: 'Products' | 'Categories' | 'Catalogs' | 'Promotions' | 'Suppliers' | 'Buyers' | 'ProductFacets';
-  @Input() resourceID: string;
+  @Input() resourceType?: ResourceType = null;
+  @Input() resourceID?: string = null;
   @Output() cancel = new EventEmitter();
   @Output() submit = new EventEmitter();
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
 }

--- a/projects/lib/src/stories/asset-list.stories.ts
+++ b/projects/lib/src/stories/asset-list.stories.ts
@@ -23,8 +23,12 @@ export default {
   ],
 };
 
+const isDefaultFilterOptionsExample = false;
+
 export const FullExample = () => ({
   component: AssetListComponent,
-  template: `<cms-asset-list [resourceType]="'Suppliers'" [resourceID]="'40009'"></cms-asset-list>`,
+  template: isDefaultFilterOptionsExample ? 
+      `<cms-asset-list [defaultFilterOptions]="{ filters: {ID: '40009-*'} }"></cms-asset-list>` :
+      `<cms-asset-list></cms-asset-list>`,
   props: {},
 });


### PR DESCRIPTION
- Assets.ListAssets will not be able to accept filtering parameters anytime soon. Refactor HeadstartSDK endpoints used to either list and create assets in favor of methods that allow filter and search parameters, or list assets per resource.
- Accept optional attribute for parameters on asset list component
- Update asset create to save File correctly