### PR TITLE
Bug fixes for Winmark

### DIFF
--- a/projects/lib/src/admin/components/html-editor/html-editor.component.ts
+++ b/projects/lib/src/admin/components/html-editor/html-editor.component.ts
@@ -182,6 +182,7 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
       this.editorOptions
     );
 
+    this.resolvedEditorOptions.file_picker_types = 'image';
     this.resolvedEditorOptions.file_picker_callback = (
       callback,
       value,
@@ -257,9 +258,15 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
       backdropClass: 'oc-tinymce-modal_backdrop',
       windowClass: 'oc-tinymce-modal_window',
     });
+
+    const assetTypes =
+      meta.filetype === 'image'
+        ? ['Image']
+        : this.assetTypes.filter((t) => t !== 'Image');
+
     this.assetPickerModalRef.componentInstance.multiple = false;
     this.assetPickerModalRef.componentInstance.tagOptions = this.tagOptions;
-    this.assetPickerModalRef.componentInstance.assetTypes = this.assetTypes;
+    this.assetPickerModalRef.componentInstance.assetTypes = assetTypes;
     this.assetPickerModalRef.componentInstance.additionalFilters = this.additionalAssetFilters;
     this.assetPickerModalRef.componentInstance.defaultListOptions = this.defaultListOptions;
     this.assetPickerModalRef.componentInstance.beforeAssetUpload = this.beforeAssetUpload;

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -119,6 +119,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
   }
 
   onPageContentChange(html: string): void {
+    console.log(JSON.stringify(html));
     this.page = { ...this.page, Content: html };
   }
 

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -119,7 +119,6 @@ export class PageEditorComponent implements OnInit, OnChanges {
   }
 
   onPageContentChange(html: string): void {
-    console.log(JSON.stringify(html));
     this.page = { ...this.page, Content: html };
   }
 

--- a/projects/lib/src/stories/page-renderer.stories.ts
+++ b/projects/lib/src/stories/page-renderer.stories.ts
@@ -41,7 +41,7 @@ export const FullExample = () => ({
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,400i,700"></link>
         `,
         Content:
-          '<div data-oc-widget=\"oc-section\">\n<div class=\"container\">\n<h2 class=\"h1 special-heading text-center border-bottom\" contenteditable=\"true\">Homepage with example images</h2>\n<div class=\"row mt-4\">\n<div class=\"col-md-4\">\n<div class=\"card border-0 bg-transparent\">\n<div class=\"card-img-top\" contenteditable=\"true\"><img class=\"img-fluid\" src=\"https://marktplacetest.blob.core.windows.net/assets-c7902848-9b45-4caf-8be5-373b150301fa/6f478868-1e97-4259-bd23-84562e2e5a93\" alt=\"Four Guitars Black, White, Blue, Brown\" width=\"352\" height=\"278\" /></div>\n<div class=\"card-body\">\n<h3 class=\"h5 card-title font-weight-bold\" contenteditable=\"true\">Column 1</h3>\n<p class=\"card-text\" contenteditable=\"true\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n</div>\n</div>\n</div>\n<div class=\"col-md-4\">\n<div class=\"card border-0 bg-transparent\">\n<div class=\"card-img-top\" contenteditable=\"true\"><img class=\"img-fluid\" src=\"https://marktplacetest.blob.core.windows.net/assets-c7902848-9b45-4caf-8be5-373b150301fa/e24046ac-139e-4b95-b04d-300bd266e089\" alt=\"Microphone on Table\" width=\"399\" height=\"300\" /></div>\n<div class=\"card-body\">\n<h3 class=\"h5 card-title font-weight-bold\" contenteditable=\"true\">Column 2</h3>\n<p class=\"card-text\" contenteditable=\"true\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n</div>\n</div>\n</div>\n<div class=\"col-md-4\">\n<div class=\"card border-0 bg-transparent\">\n<div class=\"card-img-top\" contenteditable=\"true\"><img class=\"img-fluid\" src=\"https://marktplacetest.blob.core.windows.net/assets-c7902848-9b45-4caf-8be5-373b150301fa/43166970-6a89-4f83-869c-437002fd0b0e\" alt=\"6Y5A6556.jpg\" width=\"483\" height=\"337\" /></div>\n<div class=\"card-body\">\n<h3 class=\"h5 card-title font-weight-bold\" contenteditable=\"true\">Column 2</h3>\n<p class=\"card-text\" contenteditable=\"true\">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n</div>\n</div>\n</div>\n</div>\n</div>\n</div>',
+          '<p><a name="top" href="#bottom">Go To Bottom</a></p>\n<p>&nbsp;</p>\n<div data-oc-widget="oc-section">\n<div class="jumbotron border-0">\n<div class="container text-center">\n<h1 contenteditable="true">Lorem ipsum dolor</h1>\n<p contenteditable="true">Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>\n<a class="btn btn-primary" contenteditable="true" href="#">Start Now</a> <a class="btn btn-link" contenteditable="true" href="#">Read More</a></div>\n</div>\n</div>\n<div data-oc-widget="oc-section">\n<div class="jumbotron border-0">\n<div class="container text-center">\n<h1 contenteditable="true">Lorem ipsum dolor</h1>\n<p contenteditable="true">Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>\n<a class="btn btn-primary" contenteditable="true" href="#">Start Now</a> <a class="btn btn-link" contenteditable="true" href="#">Read More</a></div>\n</div>\n</div>\n<div data-oc-widget="oc-section">\n<div class="jumbotron border-0">\n<div class="container text-center">\n<h1 contenteditable="true">Lorem ipsum dolor</h1>\n<p contenteditable="true">Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>\n<a class="btn btn-primary" contenteditable="true" href="#">Start Now</a> <a class="btn btn-link" contenteditable="true" href="#">Read More</a></div>\n</div>\n</div>\n<div data-oc-widget="oc-section">\n<div class="jumbotron border-0">\n<div class="container text-center">\n<h1 contenteditable="true">Lorem ipsum dolor</h1>\n<p contenteditable="true">Donec fermentum magna at ex pulvinar, sit amet viverra ex suscipit. Integer fringilla mauris vitae eleifend dictum.</p>\n<a class="btn btn-primary" contenteditable="true" href="#">Start Now</a> <a class="btn btn-link" contenteditable="true" href="#">Read More</a></div>\n</div>\n</div>\n<p><a name="bottom" href="#top">Go To Top</a></p>',
         FooterEmbeds: `
         <script>
           console.log('logged from footer');
@@ -79,8 +79,7 @@ export const WithContentChanging = () => ({
         <script>
           console.log('logged from header');
         </script>`,
-        Content:
-          '<h1>Page 1 content</h1>',
+        Content: '<h1>Page 1 content</h1>',
         FooterEmbeds: `
           <script>
             console.log('logged from footer');
@@ -105,9 +104,8 @@ export const WithContentChanging = () => ({
         HeaderEmbeds: `<script>
         console.log('logged from header');
       </script>`,
-        Content:
-          '<h2>Page 2 content</h2>',
-          FooterEmbeds: `
+        Content: '<h2>Page 2 content</h2>',
+        FooterEmbeds: `
           <script>
             console.log('logged from footer');
           </script>`,


### PR DESCRIPTION
**Temp change:** Only show asset picker on insert image 
_(once we have other asset types available we can show the asset picker for non-image types)_

**Prevent default anchor link behavior on buyer/page-renderer:**
1. on ngAfterViewInit find all <a> tags with an href starting with "#" (anchor links)
2. add a click event listener to each anchor link that prevents the default link behavior
3. instead of default behavior, attempt to find the corresponding named element on the page and scroll it into view