### PR TITLE
Strip contenteditable and provide dynamic text replacements nicely

### DIFF
--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -53,12 +53,12 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
       changes.pageDoc.previousValue !== changes.pageDoc.currentValue
     ) {
       const page: PageContentDoc = this.pageDoc.Doc;
-      const content = this.widgetService.applyDateRules(page.Content);
-      this.content = this.widgetService.stripEditableAttributes(content);
+      const pageContent = this.widgetService.applyDateRules(page.Content);
+      this.content = this.widgetService.stripEditableAttributes(pageContent);
       this.setMetaData(page);
       this.loadScripts(page.HeaderEmbeds, page.FooterEmbeds);
       if (this.dynamicTextReplacements && Object.keys(this.dynamicTextReplacements).length) {
-        this.content = this.replaceText(page.Content);
+        this.content = this.replaceText(this.content);
       }
     }
   }

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -53,8 +53,8 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
       changes.pageDoc.previousValue !== changes.pageDoc.currentValue
     ) {
       const page: PageContentDoc = this.pageDoc.Doc;
-      const pageContent = this.widgetService.applyDateRules(page.Content);
-      this.content = this.widgetService.stripEditableAttributes(pageContent);
+      const content = this.widgetService.applyDateRules(page.Content);
+      this.content = this.widgetService.stripEditableAttributes(content);
       this.setMetaData(page);
       this.loadScripts(page.HeaderEmbeds, page.FooterEmbeds);
       if (this.dynamicTextReplacements && Object.keys(this.dynamicTextReplacements).length) {


### PR DESCRIPTION
If `dynamicTextReplacement` data was provided, content was being set to the result of `page.Content` with the text replacements, but was losing the result of the `stripEditableAttributes` method. Pass updated content to method to replace text with given `dynamicTextReplacement` data. 