### PR TITLE
Template Date Settings - Change Hide Date Verbiage

### DIFF
--- a/projects/lib/src/admin/components/section-date-settings/section-date-settings.component.html
+++ b/projects/lib/src/admin/components/section-date-settings/section-date-settings.component.html
@@ -40,7 +40,7 @@
           aria-describedby="endDateHelp"
         />
         <small id="endDateHelp" class="form-text text-muted">
-          This section will hide starting on this date. If left blank, the
+          This section will hide at the end of this date. If left blank, the
           section will remain visible by default.
         </small>
       </div>

--- a/projects/lib/src/stories/storybook-base-configuration.ts
+++ b/projects/lib/src/stories/storybook-base-configuration.ts
@@ -5,7 +5,7 @@ import * as HeadStartSDKInstance from '@ordercloud/headstart-sdk';
 import { Configuration } from 'ordercloud-javascript-sdk';
 
 Configuration.Set({
-  baseApiUrl: 'https://sandboxapi.ordercloud.io/v1',
+  baseApiUrl: 'https://sandboxapi.ordercloud.io',
 });
 
 HeadStartSDKInstance.Configuration.Set({


### PR DESCRIPTION
Winmark users were setting a hide date and the template doesn't hide on the selected date. The current hide date verbiage is "This section will hide starting on this date. If left blank, the section will remain visible by default." So users are expecting the template to not show on that date. For example, if the hide date is set to 12/01/2020 users are expecting it to not show on this date based on the verbiage. But it actually hides it on 12/02/2020

Updated the hide date verbiage to "This section will hide at the end of this date. If left blank, the section will remain visible by default." to resolve this issue.