### PR TITLE
Resolve issues with header and footer embeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordercloud/angular-cms-components",
-  "version": "1.0.4",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2004,6 +2004,58 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
+    },
+    "@fortawesome/angular-fontawesome": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.8.2.tgz",
+      "integrity": "sha512-K/AiykA4YbHKE6XKEtZ0ZvVRQocUHyk+79HYWIfhGy3teHpzxsUqB/UjDaxivgBd6dF6ihlzgEbgrDMHlGNwGg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-1hirPcbjj72ZJtFvdnXGPbAbpn3Ox6mH3g5STbANFp3vGSiE5u5ingAKV06mK6ZVqNYxUPlh4DlTnaIvLtF2kw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-q4/p8Xehy9qiVTdDWHL4Z+o5PCLRChePGZRTXkl+/Z7erDVL8VcZUuqzJjs6gUz6czss4VIPBRdCz6wP37/zMQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
     },
     "@istanbuljs/schema": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "@angular/platform-browser": "~10.0.2",
     "@angular/platform-browser-dynamic": "~10.0.2",
     "@angular/router": "~10.0.2",
+    "@fortawesome/angular-fontawesome": "^0.8.2",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-brands-svg-icons": "^5.15.3",
+    "@fortawesome/free-regular-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "rxjs": "~6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.3"

--- a/projects/lib/src/admin/admin.module.ts
+++ b/projects/lib/src/admin/admin.module.ts
@@ -26,6 +26,7 @@ import { AssetUploadButtonComponent } from './components/asset-upload-button/ass
 import { AssetPickerComponent } from './components/asset-picker/asset-picker.component';
 import { AssetInputComponent } from './components/asset-input/asset-input.component';
 import { ThumbnailComponent } from './components/thumbnail/thumbnail.component';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 const declarations = [
   HtmlEditorComponent,
@@ -66,7 +67,7 @@ const declarations = [
     SectionDateSettingsComponent,
     PagePreviewModalComponent,
   ],
-  imports: [CmsSharedModule, CmsBuyerModule],
+  imports: [CmsSharedModule, CmsBuyerModule, FontAwesomeModule],
   exports: declarations,
 })
 export class CmsAdminModule {}

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -374,7 +374,7 @@
               <fa-icon
                 class="text-muted m-1"
                 [icon]="faQuestionCircle"
-                ngbTooltip="This is
+                ngbTooltip="Plain text is not supported in the header embed. This is
               specifically for any style or script tags needed for third party
               integrations. If you attempt to add plain text in the header
               embeds, you will not be allowed to save your changes."
@@ -396,7 +396,7 @@
                 class="text-muted m-1"
                 [icon]="faQuestionCircle"
                 ngbTooltip="The only supported tag in the footer embed is a
-              <script>. If you add anything else in the footer
+              <script>. Plain text is not supported in the footer embed. If you attempt to add plain text or add a non <script> tag in the footer
               embed, you will not be allowed to save your changes."
               ></fa-icon>
             </label>

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -364,8 +364,11 @@
             <p><b> REMINDER: </b></p>
             <p>
               Anything you add in the header or footer embeds will
-              <b>not</b> appear on your page. If you wish to add videos, text,
-              links, etc., please refer to the Content tab to add that content.
+              <b>not</b> appear on your page. The header and footer embeds are
+              used for any tags needed for third party integrations. If you wish
+              to add plain text, refer to the Content tab to add it to the page.
+              If you wish to add html code (e.g iframes), please refer to
+              Content > View > Source Code and paste the code there.
             </p>
           </div>
           <div class="form-group">
@@ -374,9 +377,8 @@
               <fa-icon
                 class="text-muted m-1"
                 [icon]="faQuestionCircle"
-                ngbTooltip="Plain text is not supported in the header embed. This is
-              specifically for any style or script tags needed for third party
-              integrations. If you attempt to add plain text in the header
+                placement="right"
+                ngbTooltip="Plain text is not supported in the header embed. If you attempt to add plain text in the header
               embeds, you will not be allowed to save your changes."
               ></fa-icon>
             </label>
@@ -395,6 +397,7 @@
               <fa-icon
                 class="text-muted m-1"
                 [icon]="faQuestionCircle"
+                placement="right"
                 ngbTooltip="The only supported tag in the footer embed is a
               <script>. Plain text is not supported in the footer embed. If you attempt to add plain text or add a non <script> tag in the footer
               embed, you will not be allowed to save your changes."

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -359,6 +359,17 @@
       <li ngbNavItem="3" [destroyOnHide]="false">
         <a ngbNavLink>Embeds</a>
         <ng-template ngbNavContent>
+          <div class="alert alert-warning py-3 my-3">
+            The following tags are what is supported in the header and footer
+            embeds:
+            <ul>
+              <li>link</li>
+              <li>meta</li>
+              <li>style</li>
+              <li>script</li>
+              <li>noscript</li>
+            </ul>
+          </div>
           <div class="form-group">
             <label for="pageHeaderEmbeds">Header Embeds</label>
             <textarea

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -353,25 +353,33 @@
             [additionalAssetFilters]="additionalAssetFilters"
             [beforeAssetUpload]="beforeAssetUpload"
             (selectedAssetChange)="selectedAssetChange.emit($event)"
-          ></cms-html-editor>
+          >
+          </cms-html-editor>
         </ng-template>
       </li>
       <li ngbNavItem="3" [destroyOnHide]="false">
         <a ngbNavLink>Embeds</a>
         <ng-template ngbNavContent>
           <div class="alert alert-warning py-3 my-3">
-            The following tags are what is supported in the header and footer
-            embeds:
-            <ul>
-              <li>link</li>
-              <li>meta</li>
-              <li>style</li>
-              <li>script</li>
-              <li>noscript</li>
-            </ul>
+            <p><b> REMINDER: </b></p>
+            <p>
+              Anything you add in the header or footer embeds will
+              <b>not</b> appear on your page. If you wish to add videos, text,
+              links, etc., please refer to the Content tab to add that content.
+            </p>
           </div>
           <div class="form-group">
-            <label for="pageHeaderEmbeds">Header Embeds</label>
+            <label for="pageHeaderEmbeds"
+              >Header Embeds
+              <fa-icon
+                class="text-muted m-1"
+                [icon]="faQuestionCircle"
+                ngbTooltip="This is
+              specifically for any style or script tags needed for third party
+              integrations. If you attempt to add plain text in the header
+              embeds, you will not be allowed to save your changes."
+              ></fa-icon>
+            </label>
             <textarea
               id="pageHeaderEmbeds"
               type="text"
@@ -382,7 +390,16 @@
             ></textarea>
           </div>
           <div class="form-group">
-            <label for="pageFooterEmbeds">Footer Embeds</label>
+            <label for="pageFooterEmbeds"
+              >Footer Embeds
+              <fa-icon
+                class="text-muted m-1"
+                [icon]="faQuestionCircle"
+                ngbTooltip="The only supported tag in the footer embed is a
+              <script>. If you add anything else in the footer
+              embed, you will not be allowed to save your changes."
+              ></fa-icon>
+            </label>
             <textarea
               id="pageFooterEmbeds"
               type="text"

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -304,7 +304,8 @@ export class PageEditorComponent implements OnInit, OnChanges {
     } else if (this.duplicateUrl) {
       this.errorMessage = 'The selected URL is already in use.';
     } else if (!this.hasValidEmbeds()) {
-      this.errorMessage = 'Please review the supported tags for the embeds';
+      this.errorMessage =
+        'Please review the supported content for the header and footer embeds';
     } else {
       this.errorMessage = undefined;
     }

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -332,10 +332,19 @@ export class PageEditorComponent implements OnInit, OnChanges {
       try {
         element = $(this.page[`${embed}`]);
       } catch {
-        // if plain text is added to the header embed, a syntax err will be thrown on the page preview
-        // for consistency, do no allow plain text for both header and footer embeds
+        // if symbols/special characters are added to the header embed, a syntax err will be thrown on the page preview
+        // for consistency, do no allow special characters for both header and footer embeds
         hasValidTags = false;
+        return;
       }
+
+      // if plain text is added to the header embed, a syntax err will be thrown on the page preview
+      // for consistency, do no allow plain text for both header and footer embeds
+      if (element.length === 0) {
+        hasValidTags = false;
+        return;
+      }
+
       element.each(function () {
         if (embed === 'FooterEmbeds') {
           // if non SCRIPT tags are added to the footer embed, it will break the page

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -28,6 +28,7 @@ import DEFAULT_ASSET_TYPES, {
 } from '../../constants/asset-types.constants';
 import { PagePreviewModalComponent } from '../page-preview-modal/page-preview-modal.component';
 import * as $ from 'jquery';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
 export const EMPTY_PAGE_CONTENT_DOC: Partial<PageContentDoc> = {
   Title: '',
@@ -80,6 +81,8 @@ export class PageEditorComponent implements OnInit, OnChanges {
   isLocked: boolean;
   isRequired: boolean;
   errorMessage: string;
+
+  faQuestionCircle = faQuestionCircle;
 
   constructor(private modalService: NgbModal) {}
 

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -330,16 +330,14 @@ export class PageEditorComponent implements OnInit, OnChanges {
     let element;
     embeds.forEach((embed) => {
       try {
-        element = $(this.page[`${embed}`]);
+        element = $(this.page[embed]);
       } catch {
-        // if symbols/special characters are added to the header embed, a syntax err will be thrown on the page preview
-        // for consistency, do no allow special characters for both header and footer embeds
+        // catch syntax err
         hasValidTags = false;
         return;
       }
 
-      // if plain text is added to the header embed, a syntax err will be thrown on the page preview
-      // for consistency, do no allow plain text for both header and footer embeds
+      // do no allow plain text for both header and footer embeds
       if (element.length === 0) {
         hasValidTags = false;
         return;

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -322,21 +322,23 @@ export class PageEditorComponent implements OnInit, OnChanges {
     if (!this.page.HeaderEmbeds && !this.page.FooterEmbeds) return true;
 
     const embeds = ['HeaderEmbeds', 'FooterEmbeds'];
-    const supportedTags = ['LINK', 'META', 'STYLE', 'NOSCRIPT', 'SCRIPT'];
     let hasValidTags = true;
+    let element;
     embeds.forEach((embed) => {
       try {
-        const element = $(this.page[`${embed}`]);
-        element.each(function () {
-          if (!this.tagName) return;
-
-          const tagNotSupported = !supportedTags.includes(this.tagName);
-          if (tagNotSupported) hasValidTags = false;
-        });
-        hasValidTags = !!element && hasValidTags;
+        element = $(this.page[`${embed}`]);
       } catch {
+        // if plain text is added to the header embed, a syntax err will be thrown on the page preview
+        // for consistency, do no allow plain text for both header and footer embeds
         hasValidTags = false;
       }
+      element.each(function () {
+        if (embed === 'FooterEmbeds') {
+          // if non SCRIPT tags are added to the footer embed, it will break the page
+          // therefore, only allow script tags to be used in the footer
+          if (this.tagName !== 'SCRIPT') hasValidTags = false;
+        }
+      });
     });
     return hasValidTags;
   }

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -160,13 +160,21 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
 
     if (content) {
       const element = $(content);
-      const scripts = element.filter(function() {
+
+      if (element.length == 0) {
+        const embed = appendTo === 'head' ? 'Header' : 'Footer';
+        console.error(
+          `ERROR: ${embed} embeds did not execute because plain text is not supported in the embeds. Please review what is supported in the ${embed} embeds in the CMS to prevent this error.`
+        );
+      }
+
+      const scripts = element.filter(function () {
         return this.tagName === 'SCRIPT';
       });
-      const nonScripts = element.filter(function() {
+      const nonScripts = element.filter(function () {
         return this.tagName !== 'SCRIPT';
       });
-      scripts.each(function() {
+      scripts.each(function () {
         // in order to run javascript after first page loads we need to append it as an html element
 
         // create script
@@ -183,7 +191,12 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
         component.renderer.appendChild(target, script);
       });
 
-      nonScripts.each(function() {
+      nonScripts.each(function () {
+        if (appendTo === 'body')
+          console.error(
+            `ERROR: Footer embeds did not execute because <${this.tagName.toLocaleLowerCase()}> is not supported in the footer. Please review what is supported in the footer embeds in the CMS to prevent this error.`
+          );
+
         // non scripts like html/css can just be added to dom
         // unlike javascript they will still be applied even after first page load
         if (this.outerHTML) {

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -193,7 +193,7 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
       });
 
       nonScripts.each(function () {
-        if (appendTo === 'body') {
+        if (appendTo === 'body' && this.tagName) {
           console.error(
             `ERROR: Footer embeds did not execute because <${this.tagName.toLocaleLowerCase()}> is not supported in the footer. Please review what is supported in the footer embeds in the CMS to prevent this error.`
           );

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -162,16 +162,13 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
       let element;
       try {
         element = $(content);
-      } catch {
-        // catch syntax err that will be thrown on the page preview, if symbols/special characters are added to the embeds
-        const embed = appendTo === 'head' ? 'Header' : 'Footer';
-        console.error(
-          `ERROR: ${embed} embeds did not execute because plain text with symbols/special characters are not supported in the embeds. Please review what is supported in the ${embed} embeds in the CMS to prevent this error.`
-        );
+      } catch (e) {
+        // catch syntax err
+        console.error(e);
         return;
       }
 
-      // catch syntax err that will be thrown on the page preview, if plain text is added to embeds
+      // plain text is not supported in embeds
       if (element.length == 0) {
         const embed = appendTo === 'head' ? 'Header' : 'Footer';
         console.error(

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -159,8 +159,19 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
     const target = component.document.getElementsByTagName(appendTo)[0];
 
     if (content) {
-      const element = $(content);
+      let element;
+      try {
+        element = $(content);
+      } catch {
+        // catch syntax err that will be thrown on the page preview, if symbols/special characters are added to the embeds
+        const embed = appendTo === 'head' ? 'Header' : 'Footer';
+        console.error(
+          `ERROR: ${embed} embeds did not execute because plain text with symbols/special characters are not supported in the embeds. Please review what is supported in the ${embed} embeds in the CMS to prevent this error.`
+        );
+        return;
+      }
 
+      // catch syntax err that will be thrown on the page preview, if plain text is added to embeds
       if (element.length == 0) {
         const embed = appendTo === 'head' ? 'Header' : 'Footer';
         console.error(

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -168,15 +168,6 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
         return;
       }
 
-      // plain text is not supported in embeds
-      if (element.length == 0) {
-        const embed = appendTo === 'head' ? 'Header' : 'Footer';
-        console.error(
-          `ERROR: ${embed} embeds did not execute because plain text is not supported in the embeds. Please review what is supported in the ${embed} embeds in the CMS to prevent this error.`
-        );
-        return;
-      }
-
       const scripts = element.filter(function () {
         return this.tagName === 'SCRIPT';
       });

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -166,6 +166,7 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
         console.error(
           `ERROR: ${embed} embeds did not execute because plain text is not supported in the embeds. Please review what is supported in the ${embed} embeds in the CMS to prevent this error.`
         );
+        return;
       }
 
       const scripts = element.filter(function () {
@@ -192,10 +193,12 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
       });
 
       nonScripts.each(function () {
-        if (appendTo === 'body')
+        if (appendTo === 'body') {
           console.error(
             `ERROR: Footer embeds did not execute because <${this.tagName.toLocaleLowerCase()}> is not supported in the footer. Please review what is supported in the footer embeds in the CMS to prevent this error.`
           );
+          return;
+        }
 
         // non scripts like html/css can just be added to dom
         // unlike javascript they will still be applied even after first page load


### PR DESCRIPTION
If users added plain text that included special characters/symbols to the header embed, a toastr error (syntax err) would be thrown on the buyer page. And if users added any non script tags in the footer, it would break the page (not show the page content) and not allow users to click on any links on the app.

To resolve this on the admin side, I made changes to not allow plain text AND  plain text with special characters/symbols in the footer or header and not allow non script tags in the footer. 

To resolve this on the buyer side, if there's an issue with the header or footer embeds, they won't be appended to the head/body. Instead, there will be errors logged in the console describing whether the issue is with the header and footer embeds.  The page should load with the correct content, not see the syntax toastr error, and function properly (e.g users are able to click on other links on the app if the footer has non script tags)

Additional changes to help user understand what is supported:
- Added tooltips next to the header and footer embeds `<label>` with text describing what is supported in each embed
- Added a REMINDER text in the Embeds tab to remind users that the header and footer embeds are used for any tags needed for third party integrations