### PR TITLE
Embeds bug: Revert changes that required both embeds to have content in order to save

### DIFF
--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -378,8 +378,7 @@
                 class="text-muted m-1"
                 [icon]="faQuestionCircle"
                 placement="right"
-                ngbTooltip="Plain text is not supported in the header embed. If you attempt to add plain text in the header
-              embeds, you will not be allowed to save your changes."
+                ngbTooltip="Plain text is not supported in the header embed."
               ></fa-icon>
             </label>
             <textarea
@@ -400,8 +399,7 @@
                 [icon]="faQuestionCircle"
                 placement="right"
                 ngbTooltip="The only supported tag in the footer embed is a
-              <script>. Plain text is not supported in the footer embed. If you attempt to add plain text or add a non <script> tag in the footer
-              embed, you will not be allowed to save your changes."
+              <script>. Plain text is not supported in the footer embed."
               ></fa-icon>
             </label>
             <textarea

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -389,6 +389,7 @@
               class="form-control"
               [(ngModel)]="page.HeaderEmbeds"
               placeholder="Copy and paste any scripts you want to execute in the <head> element"
+              (keyup)="onEmbedsChange()"
             ></textarea>
           </div>
           <div class="form-group">
@@ -410,6 +411,7 @@
               class="form-control"
               [(ngModel)]="page.FooterEmbeds"
               placeholder="Copy and paste any scripts you want to execute at the bottom of the <body> element"
+              (keyup)="onEmbedsChange()"
             ></textarea>
           </div>
         </ng-template>

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -329,27 +329,30 @@ export class PageEditorComponent implements OnInit, OnChanges {
     let hasValidTags = true;
     let element;
     embeds.forEach((embed) => {
-      try {
-        element = $(this.page[embed]);
-      } catch {
-        // catch syntax err
-        hasValidTags = false;
-        return;
-      }
-
-      // do no allow plain text for both header and footer embeds
-      if (element.length === 0) {
-        hasValidTags = false;
-        return;
-      }
-
-      element.each(function () {
-        if (embed === 'FooterEmbeds') {
-          // if non SCRIPT tags are added to the footer embed, it will break the page
-          // therefore, only allow script tags to be used in the footer
-          if (this.tagName !== 'SCRIPT') hasValidTags = false;
+      const content = this.page[embed];
+      if (content) {
+        try {
+          element = $(content);
+        } catch {
+          // catch syntax err
+          hasValidTags = false;
+          return;
         }
-      });
+
+        // do no allow plain text for both header and footer embeds
+        if (element.length === 0) {
+          hasValidTags = false;
+          return;
+        }
+
+        element.each(function () {
+          if (embed === 'FooterEmbeds') {
+            // if non SCRIPT tags are added to the footer embed, it will break the page
+            // therefore, only allow script tags to be used in the footer
+            if (this.tagName !== 'SCRIPT') hasValidTags = false;
+          }
+        });
+      }
     });
     return hasValidTags;
   }

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -370,39 +370,34 @@ export class PageEditorComponent implements OnInit, OnChanges {
   }
 
   private checkForClosingTags(content: string, embed: string): string {
-    let DOMHolderArray = [];
+    let openingTags = []; // TODO: rename?
     let tagsArray = [];
-    var lines = content.split('\n');
-    for (var x = 0; x < lines.length; x++) {
-      tagsArray = lines[x].match(
+    const lines = content.split('\n');
+    lines.forEach((line: string) => {
+      tagsArray = line.match(
         /<(\/{1})?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)>/g
       );
       if (tagsArray) {
         tagsArray.forEach((currentTag: string) => {
-          if (currentTag.indexOf('</') >= 0) {
+          const isClosingTag = currentTag.indexOf('</') >= 0;
+          if (isClosingTag) {
             let elementToRemove = currentTag.substr(2, currentTag.length - 3);
             elementToRemove = elementToRemove.replace(/ /g, '');
-            for (var j = DOMHolderArray.length - 1; j >= 0; j--) {
-              if (DOMHolderArray[j].element == elementToRemove) {
-                DOMHolderArray.splice(j, 1);
+            // TODO: can we use filter() here instead of for loop?
+            for (var j = openingTags.length - 1; j >= 0; j--) {
+              if (openingTags[j] == elementToRemove) {
+                openingTags.splice(j, 1);
                 if (elementToRemove != 'html') {
                   break;
                 }
               }
             }
           } else {
-            let tagNEW = currentTag;
-            var tag = new Object();
-            tag['full'] = currentTag;
-            if (tag['full'].indexOf(' ') > 0) {
-              tag['element'] = tag['full'].substr(
-                1,
-                tag['full'].indexOf(' ') - 1
-              );
-            } else {
-              tag['element'] = tag['full'].substr(1, tag['full'].length - 2);
-            }
-            var selfClosingTags = [
+            let tag = currentTag;
+            const length =
+              tag.indexOf(' ') > 0 ? tag.indexOf(' ') - 1 : tag.length - 2;
+            tag = currentTag.substr(1, length);
+            const selfClosingTags = [
               'area',
               'base',
               'br',

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -81,6 +81,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
   isLocked: boolean;
   isRequired: boolean;
   errorMessage: string;
+  hasValidEmbeds: boolean;
 
   faQuestionCircle = faQuestionCircle;
 
@@ -108,6 +109,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
     this.duplicateUrl = false;
     this.isLocked = this.determineLocked();
     this.isRequired = this.determineRequired();
+    this.hasValidEmbeds = this.checkEmbeds();
     this.checkErrorMessage();
   }
 
@@ -174,6 +176,10 @@ export class PageEditorComponent implements OnInit, OnChanges {
     this.page.Url = kebab(this.page.Url);
     this.onPageUrlKeyUp();
     this.checkErrorMessage();
+  }
+
+  onEmbedsChange() {
+    this.hasValidEmbeds = this.checkEmbeds();
   }
 
   onPageNavigationChange(): void {
@@ -303,7 +309,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
       this.errorMessage = 'SEO > Meta Title is required';
     } else if (this.duplicateUrl) {
       this.errorMessage = 'The selected URL is already in use.';
-    } else if (!this.hasValidEmbeds()) {
+    } else if (!this.hasValidEmbeds) {
       this.errorMessage =
         'Please review the supported content for the header and footer embeds';
     } else {
@@ -318,11 +324,11 @@ export class PageEditorComponent implements OnInit, OnChanges {
         (this.page.Url || this.isLocked) &&
         ((this.page.Active && this.isRequired) || !this.isRequired) &&
         !this.duplicateUrl &&
-        this.hasValidEmbeds()
+        this.hasValidEmbeds
     );
   }
 
-  private hasValidEmbeds(): boolean {
+  private checkEmbeds(): boolean {
     if (!this.page.HeaderEmbeds && !this.page.FooterEmbeds) return true;
 
     const embeds = ['HeaderEmbeds', 'FooterEmbeds'];

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -346,7 +346,8 @@ export class PageEditorComponent implements OnInit, OnChanges {
         }
 
         // do no allow plain text for both header and footer embeds
-        if (element.length === 0) {
+        // all content should begin with < (even if they want to add comments)
+        if (element.length === 0 || content.trim()[0] !== '<') {
           hasValidTags = false;
           return;
         }


### PR DESCRIPTION
New bug was introduction with the latest release. If you added content in the header embed, you were not able to save the page without adding content in the footer embed (vice-versa). These changes allow users to save their changes, even if they only have content in one of the embeds text box.