### PR TITLE
Remove Save Changes restrictions on the seller app

### DIFF
--- a/projects/lib/src/admin/components/page-editor/page-editor.component.html
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.html
@@ -388,7 +388,6 @@
               class="form-control"
               [(ngModel)]="page.HeaderEmbeds"
               placeholder="Copy and paste any scripts you want to execute in the <head> element"
-              (keyup)="onEmbedsChange()"
             ></textarea>
           </div>
           <div class="form-group">
@@ -409,7 +408,6 @@
               class="form-control"
               [(ngModel)]="page.FooterEmbeds"
               placeholder="Copy and paste any scripts you want to execute at the bottom of the <body> element"
-              (keyup)="onEmbedsChange()"
             ></textarea>
           </div>
         </ng-template>

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -109,7 +109,6 @@ export class PageEditorComponent implements OnInit, OnChanges {
     this.duplicateUrl = false;
     this.isLocked = this.determineLocked();
     this.isRequired = this.determineRequired();
-    this.hasValidEmbeds = this.checkEmbeds();
     this.checkErrorMessage();
   }
 
@@ -176,10 +175,6 @@ export class PageEditorComponent implements OnInit, OnChanges {
     this.page.Url = kebab(this.page.Url);
     this.onPageUrlKeyUp();
     this.checkErrorMessage();
-  }
-
-  onEmbedsChange() {
-    this.hasValidEmbeds = this.checkEmbeds();
   }
 
   onPageNavigationChange(): void {
@@ -320,123 +315,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
         this.page.MetaTitle &&
         (this.page.Url || this.isLocked) &&
         ((this.page.Active && this.isRequired) || !this.isRequired) &&
-        !this.duplicateUrl &&
-        this.hasValidEmbeds
+        !this.duplicateUrl
     );
-  }
-
-  private checkEmbeds(): boolean {
-    if (!this.page.HeaderEmbeds && !this.page.FooterEmbeds) return true;
-
-    const embeds = ['HeaderEmbeds', 'FooterEmbeds'];
-    let hasValidTags = true;
-    let element;
-    let isMissingClosingTagsMsg;
-    embeds.forEach((embed) => {
-      const content = this.page[embed];
-      if (content) {
-        try {
-          element = $(content);
-        } catch {
-          // catch syntax err
-          hasValidTags = false;
-          return;
-        }
-
-        // do no allow plain text for both header and footer embeds
-        // all content should begin with < (even if they want to add comments)
-        if (element.length === 0 || content.trim()[0] !== '<') {
-          hasValidTags = false;
-          return;
-        }
-
-        element.each(function () {
-          if (embed === 'FooterEmbeds') {
-            // if non SCRIPT tags are added to the footer embed, it will break the page
-            // therefore, only allow script tags to be used in the footer
-            if (this.tagName !== 'SCRIPT') hasValidTags = false;
-          }
-        });
-        // confirm all non self closing tags are closed
-        if (hasValidTags)
-          isMissingClosingTagsMsg = this.checkForClosingTags(content, embed);
-      }
-    });
-    this.errorMessage = !!isMissingClosingTagsMsg
-      ? isMissingClosingTagsMsg
-      : !hasValidTags
-      ? 'Please review the supported content for the header and footer embeds'
-      : undefined;
-    return hasValidTags && !isMissingClosingTagsMsg;
-  }
-
-  private checkForClosingTags(content: string, embed: string): string {
-    let openingTags = [];
-    let tagsArray = [];
-    const lines = content.split('\n');
-    lines.forEach((line: string) => {
-      tagsArray = line.match(
-        /<(\/{1})?\w+((\s+\w+(\s*=\s*(?:".*?"|'.*?'|[^'">\s]+))?)+\s*|\s*)>/g
-      );
-      if (tagsArray) {
-        tagsArray.forEach((currentTag: string) => {
-          const isClosingTag = currentTag.indexOf('</') >= 0;
-          if (isClosingTag) {
-            let closingTag = currentTag.substr(2, currentTag.length - 3);
-            closingTag = closingTag.replace(/ /g, '');
-            for (var j = openingTags.length - 1; j >= 0; j--) {
-              if (openingTags[j] == closingTag) {
-                openingTags.splice(j, 1);
-                if (closingTag != 'html') {
-                  break;
-                }
-              }
-            }
-          } else {
-            let tag = currentTag;
-            const length =
-              tag.indexOf(' ') > 0 ? tag.indexOf(' ') - 1 : tag.length - 2;
-            tag = currentTag.substr(1, length);
-            const selfClosingTags = [
-              'area',
-              'base',
-              'br',
-              'col',
-              'command',
-              'embed',
-              'hr',
-              'img',
-              'input',
-              'keygen',
-              'link',
-              'meta',
-              'param',
-              'source',
-              'track',
-              'wbr',
-            ];
-            let isSelfClosing = false;
-            selfClosingTags.forEach((selfClosingTag) => {
-              if (selfClosingTag.includes(tag)) isSelfClosing = true;
-            });
-            if (!isSelfClosing) {
-              openingTags.push(tag);
-            }
-          }
-        });
-      }
-    });
-
-    let message: string;
-    if (openingTags.length > 0) {
-      message = `The following tags don't seem to be closed in the ${embed
-        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-        .toLocaleLowerCase()}: `;
-      let tags = [];
-      tags = openingTags.map((element) => `<${element}>`);
-      const stringifyTagsArray = tags.join(', ');
-      message = message.concat(stringifyTagsArray);
-    }
-    return message;
   }
 }

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -27,7 +27,6 @@ import DEFAULT_ASSET_TYPES, {
   ASSET_TYPES,
 } from '../../constants/asset-types.constants';
 import { PagePreviewModalComponent } from '../page-preview-modal/page-preview-modal.component';
-import * as $ from 'jquery';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
 export const EMPTY_PAGE_CONTENT_DOC: Partial<PageContentDoc> = {
@@ -81,7 +80,6 @@ export class PageEditorComponent implements OnInit, OnChanges {
   isLocked: boolean;
   isRequired: boolean;
   errorMessage: string;
-  hasValidEmbeds: boolean;
 
   faQuestionCircle = faQuestionCircle;
 


### PR DESCRIPTION
Instead of disabling the Save Changes button if users added plain text or non-scripts in the footer embed, still allow them to save their changes. This isn't going to cause issues on the buyer app because if users include non-supported text in the embeds their is try/catch that catches the error and prints it in the console while the page still renders just fine