### PR TITLE
Set Robots / Indexing to Not Allowed when page is disabled

### DIFF
--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -216,12 +216,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
     const fullName = `${me.FirstName} ${me.LastName}`;
     let updated: RequiredDeep<JDocument>;
     if (document && document.ID) {
-      debugger;
-      if ((this.isLocked || this.isRequired) && !document.Doc.Active) {
-        this.page.NoRobotsIndexing = !this.page.NoRobotsIndexing;
-      } else if ((this.isLocked || this.isRequired) && document.Doc.Active) {
-        this.page.NoRobotsIndexing = !this.page.NoRobotsIndexing;
-      }
+      this.setNoRobotIndexing();
       updated = await ContentManagementClient.Documents.Save(
         this.pageSchemaID,
         document.ID,
@@ -321,5 +316,16 @@ export class PageEditorComponent implements OnInit, OnChanges {
         ((this.page.Active && this.isRequired) || !this.isRequired) &&
         !this.duplicateUrl
     );
+  }
+
+  private setNoRobotIndexing(): void {
+    const robotIndexingIsLocked = this.isLocked || this.isRequired;
+    if (robotIndexingIsLocked) {
+      // allow page to be crawled if page is active, do not allow if page is disabled
+      this.page.NoRobotsIndexing = !this.page.Active;
+    } else if (!this.page.NoRobotsIndexing && !this.page.Active) {
+      // set to true if page is disabled AND NoRobotsIndexing is undefined or false so that the page is not crawled
+      this.page.NoRobotsIndexing = true;
+    }
   }
 }

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -214,9 +214,9 @@ export class PageEditorComponent implements OnInit, OnChanges {
     const me = await OrderCloudSDK.Me.Get();
     const nowDate = new Date().toISOString();
     const fullName = `${me.FirstName} ${me.LastName}`;
+    this.setNoRobotIndexing();
     let updated: RequiredDeep<JDocument>;
     if (document && document.ID) {
-      this.setNoRobotIndexing();
       updated = await ContentManagementClient.Documents.Save(
         this.pageSchemaID,
         document.ID,

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -321,7 +321,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
   private setNoRobotIndexing(): void {
     const robotIndexingIsLocked = this.isLocked || this.isRequired;
     if (robotIndexingIsLocked) {
-      // allow page to be crawled if page is active, do not allow if page is disabled
+      // allow locked page to be crawled if page is active, do not allow if page is disabled
       this.page.NoRobotsIndexing = !this.page.Active;
     } else if (!this.page.NoRobotsIndexing && !this.page.Active) {
       // set to true if page is disabled AND NoRobotsIndexing is undefined or false so that the page is not crawled

--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -216,6 +216,12 @@ export class PageEditorComponent implements OnInit, OnChanges {
     const fullName = `${me.FirstName} ${me.LastName}`;
     let updated: RequiredDeep<JDocument>;
     if (document && document.ID) {
+      debugger;
+      if ((this.isLocked || this.isRequired) && !document.Doc.Active) {
+        this.page.NoRobotsIndexing = !this.page.NoRobotsIndexing;
+      } else if ((this.isLocked || this.isRequired) && document.Doc.Active) {
+        this.page.NoRobotsIndexing = !this.page.NoRobotsIndexing;
+      }
       updated = await ContentManagementClient.Documents.Save(
         this.pageSchemaID,
         document.ID,

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -91,7 +91,7 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
     // addTag results in dupes, so we use updateTag instead
 
     // normal metadata
-    if (page.NoRobotsIndexing || (!page.Active && !page.NoRobotsIndexing)) {
+    if (page.NoRobotsIndexing || !page.Active) {
       this.metaService.updateTag({ property: 'robots', content: 'noindex' });
     } else {
       this.metaService.removeTag('property = "robots"');

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -91,7 +91,7 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
     // addTag results in dupes, so we use updateTag instead
 
     // normal metadata
-    if (page.NoRobotsIndexing) {
+    if (page.NoRobotsIndexing || (!page.Active && !page.NoRobotsIndexing)) {
       this.metaService.updateTag({ property: 'robots', content: 'noindex' });
     } else {
       this.metaService.removeTag('property = "robots"');


### PR DESCRIPTION
Seller:
- If a locked CMS page (cannot edit the Robots / Indexing value) is disabled, then set Robots / Indexing to Not Allowed. If locked CMS page is set to active, then allow Robots / Indexing.
- When a CMS page that is not locked, is set to disabled then disallow Robots / Indexing. If users decide to set this page active again, they will have to allow Robots / Indexing in the SEO tab.

Buyer:
- Add `<meta property="robots" content="noindex">` if page.NoRobotIndexing = true OR if page is disabled