### PR TITLE
Prevent pages from getting overwritten with other page data

### DIFF
--- a/projects/lib/src/admin/components/page-editor/page-editor.component.ts
+++ b/projects/lib/src/admin/components/page-editor/page-editor.component.ts
@@ -68,6 +68,7 @@ export class PageEditorComponent implements OnInit, OnChanges {
   @Output() backClicked = new EventEmitter<MouseEvent>();
   @Output() pageSaved = new EventEmitter<JDocument>();
   @Output() pageDeleted = new EventEmitter<string>();
+  @Output() pageIsSaving = new EventEmitter<boolean>();
 
   pageSchemaID: string;
   page: Partial<PageContentDoc>;
@@ -193,8 +194,12 @@ export class PageEditorComponent implements OnInit, OnChanges {
 
   async onSubmit(): Promise<void> {
     this.isLoadingSave = true;
+    this.pageIsSaving.emit(true);
     const updated = await this.saveChanges().finally(
-      () => (this.isLoadingSave = false)
+      () => {
+        this.isLoadingSave = false;
+        this.pageIsSaving.emit(false);
+      }
     );
     this.pageSaved.emit(updated);
   }

--- a/projects/lib/src/admin/components/page-list/page-list.component.html
+++ b/projects/lib/src/admin/components/page-list/page-list.component.html
@@ -179,6 +179,7 @@
       (backClicked)="goToList($event)"
       (pageSaved)="onPageSaved($event)"
       (pageDeleted)="onPageDeleted($event)"
+      (pageIsSaving)="isPageSaving($event)"
       [renderSiteUrl]="renderSiteUrl"
       [editorOptions]="editorOptions"
       [resourceType]="resourceType"

--- a/projects/lib/src/admin/components/page-list/page-list.component.ts
+++ b/projects/lib/src/admin/components/page-list/page-list.component.ts
@@ -201,7 +201,7 @@ export class PageListComponent implements OnInit, OnChanges {
   async selectPage(page): Promise<void> {
     // if a page is in the process of saving, do not allow users to select another page
     // this is to avoid pages from getting overwritten with the other pages content
-    if (this.pageIsSaving) {
+    if (this.selected && this.pageIsSaving) {
       return;
     }
 

--- a/projects/lib/src/admin/components/page-list/page-list.component.ts
+++ b/projects/lib/src/admin/components/page-list/page-list.component.ts
@@ -63,7 +63,8 @@ export class PageListComponent implements OnInit, OnChanges {
   sortBy: string;
   faSortUp = faSortUp;
   faSortDown = faSortDown;
-
+  pageIsSaving = false;
+  
   constructor(private spinner: NgxSpinnerService) { }
 
   ngOnInit(): void {
@@ -187,6 +188,10 @@ export class PageListComponent implements OnInit, OnChanges {
     this.pageDeleted.emit(deletedId);
   }
 
+  isPageSaving(isSaving: boolean) {
+    this.pageIsSaving = isSaving;
+  }
+
   goToList(e: MouseEvent): void {
     this.selected = undefined;
     this.ngOnInit();
@@ -194,6 +199,12 @@ export class PageListComponent implements OnInit, OnChanges {
   }
 
   async selectPage(page): Promise<void> {
+    // if a page is in the process of saving, do not allow users to select another page
+    // this is to avoid pages from getting overwritten with the other pages content
+    if (this.pageIsSaving) {
+      return;
+    }
+
     if (!page) {
       // create new page
       page = {


### PR DESCRIPTION
There has received a few (3) cases where page data gets overwritten with other page data, so they lose all the content/data from one of their pages. [WIN-3166]

The only way I was able to reproduce was by saving a page, then immediately after (while the page is still saving) start clicking on different pages in the page list on the left. That's when I saw that the page I was saving was getting overwritten by one of the page I selected. I wasn't able to reproduce every time but I think these changes this will help prevent this issue from happening.

Changes include - if a page is in the process of saving, don't do anything if users attempt to select a different page in the list of pages on the left. Once the changes have been successfully updated and user click on a page, then proceed with the existing logic in `selectPage()`


[WIN-3166]: https://four51.atlassian.net/browse/WIN-3166