### PR TITLE
Use <meta normal="description"> instead of <meta property="description">

### DIFF
--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -98,11 +98,11 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
     }
     this.titleService.setTitle(page.MetaTitle);
     this.metaService.updateTag({
-      property: 'application-name',
+      name: 'application-name',
       content: page.SiteUrl,
     });
     this.metaService.updateTag({
-      property: 'description',
+      name: 'description',
       content: page.Description,
     });
 

--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -98,7 +98,7 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
     }
     this.titleService.setTitle(page.MetaTitle);
     this.metaService.updateTag({
-      name: 'application-name',
+      property: 'application-name',
       content: page.SiteUrl,
     });
     this.metaService.updateTag({


### PR DESCRIPTION
Since we were using `<meta property="description">` before, any CMS page description was not reflected on the search engines. When we use `normal="description"'` on the meta tags, the page description will be shown on search engines and resolve this issue