### PR TITLE
Add ID on scripts pasted in the header or footer embeds

### DIFF
--- a/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
+++ b/projects/lib/src/buyer/components/page-renderer/page-renderer.component.ts
@@ -180,7 +180,10 @@ export class PageRendererComponent implements OnChanges, AfterViewInit {
         // create script
         const script = component.renderer.createElement('script');
         script.type = 'text/javascript';
-
+        
+        if ((this as any).id) {
+          script.id = (this as any).id
+        }
         if ((this as any).src) {
           script.src = (this as any).src;
         } else {


### PR DESCRIPTION
If a script has an `id` attribute, include it in the script so that scripts like the Facebook Messenger Chat Plugin works correctly on the sites. For more background: https://four51.atlassian.net/browse/WIN-3196