### PR TITLE
Win-3535 CMS Pagination Fix

### DIFF
--- a/projects/lib/src/admin/components/asset-list/asset-list.component.html
+++ b/projects/lib/src/admin/components/asset-list/asset-list.component.html
@@ -74,6 +74,7 @@
       [pageSize]="meta.PageSize"
       [(page)]="meta.Page"
       (pageChange)="pageChangeEvent.emit($event)"
+      [maxSize]="25"
     ></ngb-pagination>
   </div>
   <div class="container flex-grow-1" *ngIf="!items || !items.length">


### PR DESCRIPTION
Adds a maxSize property to the pagination as several brands were facing issues with the total number of pages going off the screen. For reference: https://stylelabs.atlassian.net/browse/WIN-3535